### PR TITLE
Add fullscreen control and rename resolution options

### DIFF
--- a/index.html
+++ b/index.html
@@ -103,7 +103,7 @@
       color: #0080ff;
     }
 
-    kbd, #teleport { color: orange }
+    kbd, #teleport, #fullscreen { color: orange }
 
     #container {
       position: fixed;
@@ -130,6 +130,9 @@
       border: 1px solid;
       background: rgba(0,0,0,0.5);
       line-height: 1.5;
+    }
+    #fullscreen {
+      margin-left: 5px;
     }
 
     #keyboard-controls { display: block; }
@@ -195,9 +198,9 @@
 
 <div id="resolution">
   <h3>Resolution</h3>
-  <label><input type="radio" name="resolution" value="4"> low</label>
-  <label><input type="radio" name="resolution" value="2"> medium</label>
-  <label><input type="radio" name="resolution" value="1"> high</label>
+  <label><input type="radio" name="resolution" value="4"> 1/4 pixel</label>
+  <label><input type="radio" name="resolution" value="2"> 1/2 pixel</label>
+  <label><input type="radio" name="resolution" value="1"> full resolution</label>
 </div>
 
 <div id="version">
@@ -206,6 +209,7 @@
 
 <div class="ui-toggle">
   <label><input type="checkbox"> Hide UI</label>
+  <button id="fullscreen">Full Screen</button>
 </div>
 
 <div id="container"></div>

--- a/src/Ui.js
+++ b/src/Ui.js
@@ -3,6 +3,7 @@ class UiController {
   constructor () {
     this.initUiToggle()
     this.initTeleportButton()
+    this.initFullscreenButton()
     this.initRadioButtons()
   }
 
@@ -31,6 +32,40 @@ class UiController {
       }, false)
   }
 
+  initFullscreenButton () {
+    const button = document.querySelector('#fullscreen')
+    if (!button) {
+      return
+    }
+
+    const toggleFullscreen = () => {
+      const doc = document
+      const el = doc.documentElement
+
+      if (!doc.fullscreenElement &&
+        !doc.mozFullScreenElement &&
+        !doc.webkitFullscreenElement &&
+        !doc.msFullscreenElement) {
+        const request = el.requestFullscreen ||
+          el.mozRequestFullScreen ||
+          el.webkitRequestFullscreen ||
+          el.msRequestFullscreen
+        request && request.call(el)
+      }
+      else {
+        const exit = doc.exitFullscreen ||
+          doc.mozCancelFullScreen ||
+          doc.webkitExitFullscreen ||
+          doc.msExitFullscreen
+        exit && exit.call(doc)
+      }
+
+      button.blur()
+    }
+
+    button.addEventListener('click', toggleFullscreen, false)
+  }
+
   initRadioButtons () {
     document.querySelector('#resolution')
       .addEventListener('change', event => {
@@ -52,7 +87,7 @@ class UiController {
       return null
     }
 
-    return parseInt(element.value)
+    return parseFloat(element.value)
   }
 
   showWebGLError () {


### PR DESCRIPTION
## Summary
- rename resolution radio labels to more explicit names
- add a fullscreen button and implementation to toggle fullscreen
- parse pixel sizes as floats and support fullscreen

## Testing
- `NODE_OPTIONS=--openssl-legacy-provider npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68897cf9b37c832ba0ecf1e649bed7cf