### PR TITLE
Set up GitHub Pages build

### DIFF
--- a/.github/workflows/gh_pages.yaml
+++ b/.github/workflows/gh_pages.yaml
@@ -1,0 +1,23 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [master]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+      - run: npm install
+      - run: npm run build
+        env:
+          NODE_OPTIONS: --openssl-legacy-provider
+      - uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./dist


### PR DESCRIPTION
## Summary
- compile using Node 16 and publish the `dist` folder using `peaceiris/actions-gh-pages`

## Testing
- `NODE_OPTIONS=--openssl-legacy-provider npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6889871f0a34832b904346395c56d431