### PR TITLE
Add SSAA screenshot and real-time toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -103,7 +103,7 @@
       color: #0080ff;
     }
 
-    kbd, #teleport, #fullscreen { color: orange }
+    kbd, #teleport, #fullscreen, #screenshot { color: orange }
 
     #container {
       position: fixed;
@@ -210,6 +210,8 @@
 <div class="ui-toggle">
   <label><input type="checkbox"> Hide UI</label>
   <button id="fullscreen">Full Screen</button>
+  <button id="screenshot">Screenshot</button>
+  <label id="ssaa-control"><input type="checkbox" id="ssaa-toggle"> 8x SSAA</label>
 </div>
 
 <div id="container"></div>

--- a/src/Simulation.js
+++ b/src/Simulation.js
@@ -110,6 +110,25 @@ class Simulation {
         this.renderer.setZoom(this.renderer.zoom / 1.06)
       }
     }, false)
+
+    Ui.onScreenshotClick = () => {
+      const url = this.renderer.captureScreenshot(3)
+      const a = document.createElement('a')
+      a.href = url
+      a.download = 'screenshot.png'
+      a.click()
+    }
+
+    Ui.onSSAAEnableChange = enabled => {
+      this.renderer.setSSAAEnabled(enabled, 3)
+    }
+
+    document.addEventListener('keydown', e => {
+      if (e.keyCode === 80) { // P
+        e.preventDefault()
+        Ui.onScreenshotClick && Ui.onScreenshotClick()
+      }
+    })
   }
 
   initPlayer () {

--- a/src/Ui.js
+++ b/src/Ui.js
@@ -5,6 +5,8 @@ class UiController {
     this.initTeleportButton()
     this.initFullscreenButton()
     this.initRadioButtons()
+    this.initScreenshotButton()
+    this.initSSAA()
   }
 
   initUiToggle () {
@@ -74,6 +76,23 @@ class UiController {
         const pixelSize = this.getSelectedPixelSize()
         this.onPixelSizeChange && this.onPixelSizeChange(pixelSize)
       }, false)
+  }
+
+  initScreenshotButton () {
+    const button = document.querySelector('#screenshot')
+    if (!button) return
+    button.addEventListener('click', () => {
+      this.onScreenshotClick && this.onScreenshotClick()
+      button.blur()
+    }, false)
+  }
+
+  initSSAA () {
+    const checkbox = document.querySelector('#ssaa-toggle')
+    if (!checkbox) return
+    checkbox.addEventListener('change', () => {
+      this.onSSAAEnableChange && this.onSSAAEnableChange(checkbox.checked)
+    }, false)
   }
 
   setPixelSize (value) {

--- a/src/postprocessing/SSAARenderPass.js
+++ b/src/postprocessing/SSAARenderPass.js
@@ -1,0 +1,162 @@
+import {
+  WebGLRenderTarget,
+  LinearFilter,
+  RGBAFormat,
+  ShaderMaterial,
+  UniformsUtils,
+  AdditiveBlending,
+  OrthographicCamera,
+  Scene,
+  Mesh,
+  PlaneBufferGeometry
+} from 'three'
+
+import Pass from './Pass'
+import CopyShader from './CopyShader'
+
+export default class SSAARenderPass extends Pass {
+
+  constructor (scene, camera, clearColor, clearAlpha) {
+    super()
+
+    this.scene = scene
+    this.camera = camera
+
+    // Number of samples is 2^sampleLevel
+    this.sampleLevel = 4
+    this.unbiased = true
+
+    this.clearColor = clearColor !== undefined ? clearColor : 0x000000
+    this.clearAlpha = clearAlpha !== undefined ? clearAlpha : 0
+
+    const copyShader = CopyShader
+    this.copyUniforms = UniformsUtils.clone(copyShader.uniforms)
+
+    this.copyMaterial = new ShaderMaterial({
+      uniforms: this.copyUniforms,
+      vertexShader: copyShader.vertexShader,
+      fragmentShader: copyShader.fragmentShader,
+      premultipliedAlpha: true,
+      transparent: true,
+      blending: AdditiveBlending,
+      depthTest: false,
+      depthWrite: false
+    })
+
+    this.camera2 = new OrthographicCamera(-1, 1, 1, -1, 0, 1)
+    this.scene2 = new Scene()
+    this.quad2 = new Mesh(new PlaneBufferGeometry(2, 2), this.copyMaterial)
+    this.quad2.frustumCulled = false
+    this.scene2.add(this.quad2)
+  }
+
+  dispose () {
+    if (this.sampleRenderTarget) {
+      this.sampleRenderTarget.dispose()
+      this.sampleRenderTarget = null
+    }
+  }
+
+  setSize (width, height) {
+    if (this.sampleRenderTarget) {
+      this.sampleRenderTarget.setSize(width, height)
+    }
+  }
+
+  render (renderer, writeBuffer, readBuffer) {
+    if (!this.sampleRenderTarget) {
+      this.sampleRenderTarget = new WebGLRenderTarget(readBuffer.width, readBuffer.height, {
+        minFilter: LinearFilter,
+        magFilter: LinearFilter,
+        format: RGBAFormat
+      })
+      this.sampleRenderTarget.texture.name = 'SSAARenderPass.sample'
+    }
+
+    const jitterOffsets = SSAARenderPass.JitterVectors[Math.max(0, Math.min(this.sampleLevel, 5))]
+
+    const autoClear = renderer.autoClear
+    renderer.autoClear = false
+
+    const oldClearColor = renderer.getClearColor().getHex()
+    const oldClearAlpha = renderer.getClearAlpha()
+
+    const baseSampleWeight = 1.0 / jitterOffsets.length
+    const roundingRange = 1 / 32
+    this.copyUniforms.tDiffuse.value = this.sampleRenderTarget.texture
+
+    const width = readBuffer.width
+    const height = readBuffer.height
+
+    for (let i = 0; i < jitterOffsets.length; i++) {
+      const jitterOffset = jitterOffsets[i]
+
+      if (this.camera.setViewOffset) {
+        this.camera.setViewOffset(
+          width,
+          height,
+          jitterOffset[0] * 0.0625,
+          jitterOffset[1] * 0.0625,
+          width,
+          height
+        )
+      }
+
+      let sampleWeight = baseSampleWeight
+
+      if (this.unbiased) {
+        const uniformCenteredDistribution = -0.5 + (i + 0.5) / jitterOffsets.length
+        sampleWeight += roundingRange * uniformCenteredDistribution
+      }
+
+      this.copyUniforms.opacity.value = sampleWeight
+      renderer.setClearColor(this.clearColor, this.clearAlpha)
+      renderer.render(this.scene, this.camera, this.sampleRenderTarget, true)
+
+      if (i === 0) {
+        renderer.setClearColor(0x000000, 0.0)
+      }
+
+      renderer.render(this.scene2, this.camera2, this.renderToScreen ? null : writeBuffer, i === 0)
+    }
+
+    if (this.camera.clearViewOffset) this.camera.clearViewOffset()
+
+    renderer.autoClear = autoClear
+    renderer.setClearColor(oldClearColor, oldClearAlpha)
+
+  }
+
+}
+
+SSAARenderPass.JitterVectors = [
+  [
+    [0, 0]
+  ],
+  [
+    [4, 4], [-4, -4]
+  ],
+  [
+    [-2, -6], [6, -2], [-6, 2], [2, 6]
+  ],
+  [
+    [1, -3], [-1, 3], [5, 1], [-3, -5],
+    [-5, 5], [-7, -1], [3, 7], [7, -7]
+  ],
+  [
+    [1, 1], [-1, -3], [-3, 2], [4, -1],
+    [-5, -2], [2, 5], [5, 3], [3, -5],
+    [-2, 6], [0, -7], [-4, -6], [-6, 4],
+    [-8, 0], [7, -4], [6, 7], [-7, -8]
+  ],
+  [
+    [-4, -7], [-7, -5], [-3, -5], [-5, -4],
+    [-1, -4], [-2, -2], [-6, -1], [-4, 0],
+    [-7, 1], [-1, 2], [-6, 3], [-3, 3],
+    [-7, 6], [-3, 6], [-5, 7], [-1, 7],
+    [5, -7], [1, -6], [6, -5], [4, -4],
+    [2, -3], [7, -2], [1, -1], [4, -1],
+    [2, 1], [6, 2], [0, 4], [4, 4],
+    [2, 5], [7, 5], [5, 6], [3, 7]
+  ]
+]


### PR DESCRIPTION
## Summary
- implement SSAARenderPass module
- use SSAA pass in renderer and support enabling/disabling
- provide method for capturing screenshots with SSAA
- add UI controls for screenshots and SSAA toggle
- hook up screenshot and SSAA handlers in Simulation

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688aa7cf06fc832ba93c72554bb4f3b7