### PR TITLE
Add SSAA screenshot and realtime option

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,6 +74,23 @@
       display: block;
     }
 
+    #ssaa {
+      position: fixed;
+      bottom: 0;
+      left: 0;
+      padding: 5px;
+      z-index: 10;
+    }
+
+    .no-ui #ssaa {
+      -webkit-transform: translateX(-100%);
+      transform: translateX(-100%);
+    }
+
+    #ssaa > label {
+      display: block;
+    }
+
     .ui-toggle {
       position: fixed;
       bottom: 5px;
@@ -132,6 +149,9 @@
       line-height: 1.5;
     }
     #fullscreen {
+      margin-left: 5px;
+    }
+    #screenshot {
       margin-left: 5px;
     }
 
@@ -203,6 +223,14 @@
   <label><input type="radio" name="resolution" value="1"> full resolution</label>
 </div>
 
+<div id="ssaa">
+  <h3>SSAA</h3>
+  <label><input type="radio" name="ssaa" value="1" checked> off</label>
+  <label><input type="radio" name="ssaa" value="2"> 2x</label>
+  <label><input type="radio" name="ssaa" value="4"> 4x</label>
+  <label><input type="radio" name="ssaa" value="8"> 8x</label>
+</div>
+
 <div id="version">
   <a target="_blank" href="https://github.com/sirxemic/Interstellar">version 2.0.1</a>
 </div>
@@ -210,6 +238,7 @@
 <div class="ui-toggle">
   <label><input type="checkbox"> Hide UI</label>
   <button id="fullscreen">Full Screen</button>
+  <button id="screenshot">Screenshot</button>
 </div>
 
 <div id="container"></div>

--- a/src/Simulation.js
+++ b/src/Simulation.js
@@ -84,6 +84,15 @@ class Simulation {
       this.renderer.setPixelSize(pixelSize)
     }
 
+    Ui.onSSAAChange = samples => {
+      this.renderer.setSSAA(samples)
+    }
+
+    Ui.onScreenshot = () => {
+      const samples = Ui.getSelectedSSAA ? Ui.getSelectedSSAA() : 1
+      this.renderer.saveScreenshot(samples)
+    }
+
     window.addEventListener(
       'resize', e => {
         this.renderer.setSize(window.innerWidth, window.innerHeight)
@@ -96,6 +105,9 @@ class Simulation {
       pixelSize = this.getSuggestedPixelSize()
       Ui.setPixelSize(pixelSize)
     }
+
+    const ssaa = Ui.getSelectedSSAA ? Ui.getSelectedSSAA() : 1
+    this.renderer.setSSAA(ssaa)
 
     this.renderer.setSize(window.innerWidth, window.innerHeight, pixelSize)
 
@@ -161,6 +173,12 @@ class Simulation {
         e.preventDefault()
 
         this.teleporter.teleportNext()
+      }
+      else if (e.keyCode === 80) {
+        e.preventDefault()
+
+        const samples = Ui.getSelectedSSAA ? Ui.getSelectedSSAA() : 1
+        this.renderer.saveScreenshot(samples)
       }
     })
   }

--- a/src/Ui.js
+++ b/src/Ui.js
@@ -5,6 +5,8 @@ class UiController {
     this.initTeleportButton()
     this.initFullscreenButton()
     this.initRadioButtons()
+    this.initSSAARadioButtons()
+    this.initScreenshotButton()
   }
 
   initUiToggle () {
@@ -76,6 +78,31 @@ class UiController {
       }, false)
   }
 
+  initSSAARadioButtons () {
+    const container = document.querySelector('#ssaa')
+    if (!container) {
+      return
+    }
+
+    container.addEventListener('change', event => {
+      event.target.blur()
+
+      const ssaa = this.getSelectedSSAA()
+      this.onSSAAChange && this.onSSAAChange(ssaa)
+    }, false)
+  }
+
+  initScreenshotButton () {
+    const button = document.getElementById('screenshot')
+    if (!button) {
+      return
+    }
+    button.addEventListener('click', () => {
+      this.onScreenshot && this.onScreenshot()
+      button.blur()
+    }, false)
+  }
+
   setPixelSize (value) {
     document.querySelector(`[name=resolution][value="${value}"]`).checked = true
   }
@@ -88,6 +115,19 @@ class UiController {
     }
 
     return parseFloat(element.value)
+  }
+
+  setSSAA (value) {
+    const el = document.querySelector(`[name=ssaa][value="${value}"]`)
+    if (el) el.checked = true
+  }
+
+  getSelectedSSAA () {
+    const element = document.querySelector('[name=ssaa]:checked')
+    if (!element) {
+      return 1
+    }
+    return parseInt(element.value, 10)
   }
 
   showWebGLError () {

--- a/src/postprocessing/SSAARenderPass.js
+++ b/src/postprocessing/SSAARenderPass.js
@@ -1,0 +1,152 @@
+import {
+  WebGLRenderTarget,
+  LinearFilter,
+  RGBAFormat,
+  ShaderMaterial,
+  AdditiveBlending,
+  UniformsUtils,
+  OrthographicCamera,
+  Scene,
+  Mesh,
+  PlaneBufferGeometry
+} from 'three'
+
+import Pass from './Pass'
+import CopyShader from './CopyShader'
+
+export default class SSAARenderPass extends Pass {
+
+  constructor (scene, camera, clearColor = 0x000000, clearAlpha = 0) {
+    super()
+
+    this.scene = scene
+    this.camera = camera
+
+    this.sampleLevel = 4 // 2^4 = 16 samples by default
+    this.unbiased = true
+
+    this.clearColor = clearColor
+    this.clearAlpha = clearAlpha
+
+    this.copyUniforms = UniformsUtils.clone(CopyShader.uniforms)
+    this.copyMaterial = new ShaderMaterial({
+      uniforms: this.copyUniforms,
+      vertexShader: CopyShader.vertexShader,
+      fragmentShader: CopyShader.fragmentShader,
+      premultipliedAlpha: true,
+      transparent: true,
+      blending: AdditiveBlending,
+      depthTest: false,
+      depthWrite: false
+    })
+
+    this.camera2 = new OrthographicCamera(-1, 1, 1, -1, 0, 1)
+    this.scene2 = new Scene()
+    this.quad2 = new Mesh(new PlaneBufferGeometry(2, 2), this.copyMaterial)
+    this.quad2.frustumCulled = false
+    this.scene2.add(this.quad2)
+  }
+
+  dispose () {
+    if (this.sampleRenderTarget) {
+      this.sampleRenderTarget.dispose()
+      this.sampleRenderTarget = null
+    }
+  }
+
+  setSize (width, height) {
+    if (this.sampleRenderTarget) {
+      this.sampleRenderTarget.setSize(width, height)
+    }
+  }
+
+  render (renderer, writeBuffer, readBuffer) {
+    if (!this.sampleRenderTarget) {
+      this.sampleRenderTarget = new WebGLRenderTarget(readBuffer.width, readBuffer.height, {
+        minFilter: LinearFilter,
+        magFilter: LinearFilter,
+        format: RGBAFormat
+      })
+      this.sampleRenderTarget.texture.name = 'SSAARenderPass.sample'
+    }
+
+    const jitterOffsets = SSAARenderPass.JitterVectors[Math.max(0, Math.min(this.sampleLevel, 5))]
+
+    const autoClear = renderer.autoClear
+    renderer.autoClear = false
+
+    const oldClearColor = renderer.getClearColor().getHex()
+    const oldClearAlpha = renderer.getClearAlpha()
+
+    const baseSampleWeight = 1.0 / jitterOffsets.length
+    const roundingRange = 1 / 32
+    this.copyUniforms.tDiffuse.value = this.sampleRenderTarget.texture
+
+    const width = readBuffer.width
+    const height = readBuffer.height
+
+    for (let i = 0; i < jitterOffsets.length; i++) {
+      const jitterOffset = jitterOffsets[i]
+
+      if (this.camera.setViewOffset) {
+        this.camera.setViewOffset(width, height,
+          jitterOffset[0] * 0.0625, jitterOffset[1] * 0.0625,
+          width, height)
+      }
+
+      let sampleWeight = baseSampleWeight
+      if (this.unbiased) {
+        const uniformCenteredDistribution = (-0.5 + (i + 0.5) / jitterOffsets.length)
+        sampleWeight += roundingRange * uniformCenteredDistribution
+      }
+
+      this.copyUniforms.opacity.value = sampleWeight
+      renderer.setClearColor(this.clearColor, this.clearAlpha)
+      renderer.render(this.scene, this.camera, this.sampleRenderTarget, true)
+
+      if (i === 0) {
+        renderer.setClearColor(0x000000, 0.0)
+      }
+
+      renderer.render(this.scene2, this.camera2, this.renderToScreen ? null : writeBuffer, (i === 0))
+    }
+
+    if (this.camera.clearViewOffset) this.camera.clearViewOffset()
+
+    renderer.autoClear = autoClear
+    renderer.setClearColor(oldClearColor, oldClearAlpha)
+  }
+
+}
+
+SSAARenderPass.JitterVectors = [
+  [
+    [0, 0]
+  ],
+  [
+    [4, 4], [-4, -4]
+  ],
+  [
+    [-2, -6], [6, -2], [-6, 2], [2, 6]
+  ],
+  [
+    [1, -3], [-1, 3], [5, 1], [-3, -5],
+    [-5, 5], [-7, -1], [3, 7], [7, -7]
+  ],
+  [
+    [1, 1], [-1, -3], [-3, 2], [4, -1],
+    [-5, -2], [2, 5], [5, 3], [3, -5],
+    [-2, 6], [0, -7], [-4, -6], [-6, 4],
+    [-8, 0], [7, -4], [6, 7], [-7, -8]
+  ],
+  [
+    [-4, -7], [-7, -5], [-3, -5], [-5, -4],
+    [-1, -4], [-2, -2], [-6, -1], [-4, 0],
+    [-7, 1], [-1, 2], [-6, 3], [-3, 3],
+    [-7, 6], [-3, 6], [-5, 7], [-1, 7],
+    [5, -7], [1, -6], [6, -5], [4, -4],
+    [2, -3], [7, -2], [1, -1], [4, -1],
+    [2, 1], [6, 2], [0, 4], [4, 4],
+    [2, 5], [7, 5], [5, 6], [3, 7]
+  ]
+]


### PR DESCRIPTION
## Summary
- add SSAA controls and screenshot button to the UI
- integrate SSAA pass and screenshot support in the renderer
- hook up SSAA controls in simulation logic
- expose UI helpers for SSAA and screenshot

## Testing
- `npx eslint .`
- `NODE_OPTIONS=--openssl-legacy-provider npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688aa7cf06fc832ba93c72554bb4f3b7