### PR TITLE
Fix RenderPass import

### DIFF
--- a/src/SimulationRenderer.js
+++ b/src/SimulationRenderer.js
@@ -22,6 +22,7 @@ import {
 } from 'three'
 
 import EffectComposer from './postprocessing/EffectComposer'
+import RenderPass from './postprocessing/RenderPass'
 import BloomPass from './postprocessing/UnrealBloomPass'
 import SSAARenderPass from './postprocessing/SSAARenderPass'
 


### PR DESCRIPTION
## Summary
- include RenderPass import in SimulationRenderer

## Testing
- `npx eslint src`
- `NODE_OPTIONS=--openssl-legacy-provider npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688aadd85058832bbe6a5bbdc0053804