### PR TITLE
Fix SSAA rendering

### DIFF
--- a/src/postprocessing/SSAARenderPass.js
+++ b/src/postprocessing/SSAARenderPass.js
@@ -108,7 +108,12 @@ export default class SSAARenderPass extends Pass {
         renderer.setClearColor(0x000000, 0.0)
       }
 
-      renderer.render(this.scene2, this.camera2, this.renderToScreen ? null : writeBuffer, (i === 0))
+      renderer.render(
+        this.scene2,
+        this.camera2,
+        this.renderToScreen ? null : readBuffer,
+        i === 0
+      )
     }
 
     if (this.camera.clearViewOffset) this.camera.clearViewOffset()


### PR DESCRIPTION
## Summary
- write SSAA results into the buffer subsequent passes use

## Testing
- `NODE_OPTIONS=--openssl-legacy-provider npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688aafa15088832b9efe3b272efa07f5