### PR TITLE
Fix SSAA button overlap

### DIFF
--- a/index.html
+++ b/index.html
@@ -76,7 +76,7 @@
 
     #ssaa {
       position: fixed;
-      bottom: 0;
+      bottom: 60px;
       left: 0;
       padding: 5px;
       z-index: 10;


### PR DESCRIPTION
## Summary
- bump `#ssaa` control slightly above the UI toggle to avoid overlap

## Testing
- `NODE_OPTIONS=--openssl-legacy-provider npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688ab154fcd4832b9d2b46b883bb6f11